### PR TITLE
Update authentication_context.py

### DIFF
--- a/office365/runtime/auth/authentication_context.py
+++ b/office365/runtime/auth/authentication_context.py
@@ -17,18 +17,18 @@ class AuthenticationContext(object):
         self.authority_url = authority_url
         self._provider = None
 
-    def with_client_certificate(self, tenant, client_id, thumbprint, cert_path):
+    def with_client_certificate(self, tenant, client_id, thumbprint, cert_path,scopes=["{url}/.default".format(url=self.authority_url)]):
         """Creates authenticated SharePoint context via certificate credentials
 
         :param str tenant: Tenant name, for example {}@
         :param str cert_path: Path to A PEM encoded certificate private key.
         :param str thumbprint: Hex encoded thumbprint of the certificate.
         :param str client_id: The OAuth client id of the calling application.
+        :param list[str] scopes :  Scopes requested to access a protected API (a resource)
         """
 
         def _acquire_token_for_client_certificate():
             authority_url = 'https://login.microsoftonline.com/{0}'.format(tenant)
-            scopes = ["{url}/.default".format(url=self.authority_url)]
             credentials = {"thumbprint": thumbprint, "private_key": open(cert_path).read()}
             import msal
             app = msal.ConfidentialClientApplication(


### PR DESCRIPTION
Hi, i was getting the following error with your code when trying to connect my app to SP, using client certificate:

ValueError: {'error': 'invalid_resource', 'error_description': 'AADSTS500011: The resource principal named {SP_site_url} was not found in the tenant named{tenant_id}. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant.\r\nTrace ID: e9b28e6f-2f96-43d7-8ca7-753613b69100\r\nCorrelation ID: 4b2ed2a3-76fb-437c-afec-0f973bd13728\r\nTimestamp: 2022-01-21 11:08:23Z', 'error_codes': [500011], 'timestamp': '2022-01-21 11:08:23Z', 'trace_id': 'e9b28e6f-2f96-43d7-8ca7-753613b69100', 'correlation_id': '4b2ed2a3-76fb-437c-afec-0f973bd13728', 'error_uri': 'https://login.microsoftonline.com/error?code=500011'} , although my app had all the necessary permissions and consent ,according to : https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/security-apponly-azuread

I managed to fix the error by setting scopes='https://{my_company_name}.sharepoint.com/.default',rather than 'https://login.microsoftonline.com/{tenant_id}/.default, following the suggestion of many users I have found online. I am not sure why you have set the scopes in this format, perhaps it works for other users, by in any case i find it very helpful to have the ability to set a custom scope when calling the with_client_certificate func. I have let the value that you have set as the default one. Hopefully, this can help other users that have the same problem as i did.